### PR TITLE
Fix for UTF-8 error in SmarterCSV

### DIFF
--- a/lib/barclays-to-ynab.rb
+++ b/lib/barclays-to-ynab.rb
@@ -6,7 +6,9 @@ module BarclaysToYnab
   class Converter
     def convert(path)
       new_path = path + '.ynab.csv'
-      transactions = SmarterCSV.process(path)
+      file = File.open(path, "r:ISO-8859-1")
+      transactions = SmarterCSV.process(file)
+      file.close
       headers = %w(Date Payee Memo Inflow Outflow Category)
 
       File.open(new_path, 'w') do |f|


### PR DESCRIPTION
I received the following error when running:

```
/Library/Ruby/Gems/2.0.0/gems/smarter_csv-1.1.0/lib/smarter_csv/smarter_csv.rb:93:in `=~': invalid byte sequence in UTF-8 (ArgumentError)
    from /Library/Ruby/Gems/2.0.0/gems/smarter_csv-1.1.0/lib/smarter_csv/smarter_csv.rb:93:in `process'
    from /Library/Ruby/Gems/2.0.0/gems/barclays-to-ynab-1.0.2/lib/barclays-to-ynab.rb:9:in `convert'
    from /Library/Ruby/Gems/2.0.0/gems/barclays-to-ynab-1.0.2/bin/barclays-to-ynab:19:in `<top (required)>'
    from /usr/bin/barclays-to-ynab:23:in `load'
    from /usr/bin/barclays-to-ynab:23:in `<main>
```

This PR forces it to read the CSV file as ISO-8859-1 instead.
